### PR TITLE
IArgumentMarshaler auf generischen Enumerator umgestellt

### DIFF
--- a/Utilities/BooleanArgumentMarshaler.cs
+++ b/Utilities/BooleanArgumentMarshaler.cs
@@ -1,4 +1,6 @@
-﻿namespace Utilities
+﻿using System.Collections.Generic;
+
+namespace Utilities
 {
     public class BooleanArgumentMarshaler : IArgumentMarshaler
     {
@@ -6,7 +8,7 @@
 
         #region IArgumentMarshaler Member
 
-        public void SetArgument(System.Collections.Generic.List<string>.Enumerator argument)
+        public void SetArgument(IEnumerator<string> argument)
         {
             _value = true;
         }

--- a/Utilities/DoubleArgumentMarshaler.cs
+++ b/Utilities/DoubleArgumentMarshaler.cs
@@ -10,7 +10,7 @@ namespace Utilities
 
         #region IArgumentMarshaler Member
 
-        public void SetArgument(List<string>.Enumerator argument)
+        public void SetArgument(IEnumerator<string> argument)
         {
             try
             {

--- a/Utilities/IArgumentMarshaler.cs
+++ b/Utilities/IArgumentMarshaler.cs
@@ -1,11 +1,10 @@
-﻿
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Utilities
 {
     public interface IArgumentMarshaler
     {
-        void SetArgument(List<string>.Enumerator argument);
+        void SetArgument(IEnumerator<string> argument);
 
         object GetValue();
     }

--- a/Utilities/IntegerArgumentMarshaler.cs
+++ b/Utilities/IntegerArgumentMarshaler.cs
@@ -10,7 +10,7 @@ namespace Utilities
 
         #region IArgumentMarshaler Member
 
-        public void SetArgument(List<string>.Enumerator argument)
+        public void SetArgument(IEnumerator<string> argument)
         {
             try
             {

--- a/Utilities/StringArgumentMarshaler.cs
+++ b/Utilities/StringArgumentMarshaler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Utilities
 {
@@ -8,7 +9,7 @@ namespace Utilities
 
         #region IArgumentMarshaler Member
 
-        public void SetArgument(System.Collections.Generic.List<string>.Enumerator argument)
+        public void SetArgument(IEnumerator<string> argument)
         {
             try
             {


### PR DESCRIPTION
Die Verwendung von `List<string>.Enumerator` ist zu speziell. Die Abstrahierung zu `IEnumerator<string>` erlaubt mehrere Verwendungsmöglichkeiten.
